### PR TITLE
Install ruv-swarm globally

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ This repository provides a VS Code development container for running claude-flow
 
 ### ruv-FANN Installation
 - Cloned to `/workspace/deps/ruv-FANN` for development and updates
-- ruv-swarm installed with `--production` flag to skip devDependencies
+- ruv-swarm installed globally from source (`npm install -g . --force`) with `--production` deps
 - Local ruv-swarm MCP server automatically configured
 
 ### Development Benefits
@@ -124,7 +124,7 @@ claude-flow --version
 ### MCP Servers
 The container automatically configures two local MCP servers for faster connections:
 - **claude-flow**: Uses the locally installed claude-flow package
-- **ruv-swarm**: Uses the locally cloned ruv-FANN installation
+- **ruv-swarm**: Uses the globally installed ruv-swarm from the ruv-FANN source
 
 To manually reconfigure:
 ```bash
@@ -134,7 +134,7 @@ claude mcp add claude-flow claude-flow mcp start
 
 # Remove and re-add ruv-swarm
 claude mcp remove ruv-swarm
-claude mcp add ruv-swarm /workspace/deps/ruv-FANN/ruv-swarm/npm/bin/ruv-swarm-secure.js mcp start
+claude mcp add ruv-swarm ruv-swarm mcp start
 ```
 
 ### Development
@@ -178,6 +178,8 @@ cd /workspace/deps/ruv-FANN/ruv-swarm/npm
 npm install --production
 # or for newer npm versions:
 npm install --omit=dev
+# install globally
+npm install -g . --force
 ```
 
 The MCP configuration will work normally since wasm-opt is not required for runtime operation of ruv-swarm.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A secure, isolated development container for running agentic swarms, and CLIs wi
 ## ✨ Highlights
 
 - **🛡️ Isolated Security** - Container-level firewall and network isolation keeps your host system safe while experimenting with AI agents
-- **🚀 Bleeding Edge Updates** - Claude Flow and ruv-swarm installed from source, giving you instant access to the latest features from main branch
+- **🚀 Bleeding Edge Updates** - Claude Flow and ruv-swarm installed from source and available globally, giving you instant access to the latest features from main branch
 - **💻 Local Development Ready** - Full source code for both claude-flow and ruv-FANN in your workspace - modify, test, and contribute back
 - **⚡ Zero-Latency MCP** - Local MCP servers eliminate network roundtrips for lightning-fast agent coordination
 - **🔧 Production + Development** - Global npm installs for reliability, plus source code for hacking and exploration
@@ -226,7 +226,7 @@ The container includes:
   - 🔄 Easy updates with `npm update -g claude-flow@alpha`
 - **ruv-FANN** - Neural network swarm framework
   - 📂 Full source in `/workspace/deps/ruv-FANN` for development
-  - 🚀 ruv-swarm MCP server auto-configured for local connections
+  - 🚀 ruv-swarm installed globally from source with MCP auto-configured for local connections
   - 🔧 Production dependencies only (no build issues)
 
 ### 🛡️ Security Features

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -8,7 +8,7 @@ This document tracks the current working versions of the core components in the 
 |-----------|---------|--------|-------|
 | **Claude Code** | v1.0.51 | npm: `@anthropic-ai/claude-code` | Installed globally via npm |
 | **Claude Flow** | v2.0.0-alpha.53 | npm: `claude-flow@alpha` | Installed globally from npm, source in `/workspace/deps/claude-flow` |
-| **ruv-FANN/ruv-swarm** | v1.0.18 | GitHub: `ruvnet/ruv-FANN` | Cloned to `/workspace/deps/ruv-FANN`, ruv-swarm installed with `--production` |
+| **ruv-FANN/ruv-swarm** | v1.0.18 | GitHub: `ruvnet/ruv-FANN` | Cloned to `/workspace/deps/ruv-FANN`, ruv-swarm installed globally from source with `--production` deps |
 
 ## Container Base
 
@@ -52,6 +52,7 @@ cd /workspace/deps/ruv-FANN
 git pull origin main
 cd ruv-swarm/npm
 npm install --production
+npm install -g . --force
 ```
 
 ## Version Compatibility


### PR DESCRIPTION
## Summary
- install ruv‑swarm globally from source in postCreate
- configure MCP to use `ruv-swarm` command
- document global install of ruv-swarm
- note update steps in VERSIONS and CLAUDE docs

## Testing
- `bash .devcontainer/scripts/tests/test-devcontainer.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687805dbb564832382a8ffe706e4a924