### PR TITLE
Add Gemini CLI support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -50,6 +50,7 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 # Install global npm packages
 RUN npm install -g \
     @anthropic-ai/claude-code \
+    @google/gemini-cli \
     npm-check-updates \
     typescript \
     ts-node \

--- a/.devcontainer/scripts/hooks/postCreate.sh
+++ b/.devcontainer/scripts/hooks/postCreate.sh
@@ -289,11 +289,13 @@ if [ ! -f ~/.swarm_history_added ]; then
         print -s 'claude-flow hive-mind spawn "build me something amazing" --queen-type adaptive --max-workers 5 --claude'
         print -s "claude-flow hive-mind wizard"
         print -s "claude --dangerously-skip-permissions"
+        print -s "gemini --help"
         
         # Also add to history file
         echo ": $(date +%s):0;claude-flow hive-mind spawn \"build me something amazing\" --queen-type adaptive --max-workers 5 --claude" >> ~/.zsh_history
         echo ": $(date +%s):0;claude-flow hive-mind wizard" >> ~/.zsh_history
         echo ": $(date +%s):0;claude --dangerously-skip-permissions" >> ~/.zsh_history
+        echo ": $(date +%s):0;gemini --help" >> ~/.zsh_history
     fi
     
     # For bash
@@ -302,11 +304,13 @@ if [ ! -f ~/.swarm_history_added ]; then
         history -s 'claude-flow hive-mind spawn "build me something amazing" --queen-type adaptive --max-workers 5 --claude'
         history -s "claude-flow hive-mind wizard"
         history -s "claude --dangerously-skip-permissions"
+        history -s "gemini --help"
         
         # Also add to history file
         echo "claude-flow hive-mind spawn \"build me something amazing\" --queen-type adaptive --max-workers 5 --claude" >> ~/.bash_history
         echo "claude-flow hive-mind wizard" >> ~/.bash_history
         echo "claude --dangerously-skip-permissions" >> ~/.bash_history
+        echo "gemini --help" >> ~/.bash_history
     fi
     
     # Mark as added

--- a/.devcontainer/scripts/security/security-monitor.sh
+++ b/.devcontainer/scripts/security/security-monitor.sh
@@ -102,6 +102,19 @@ check_claude_integrity() {
     fi
 }
 
+# Function to check Gemini CLI integrity
+check_gemini_integrity() {
+    echo -e "${YELLOW}Checking Gemini CLI integrity...${NC}"
+
+    GEMINI_VERSION=$(gemini --version 2>/dev/null)
+    if [[ -z "$GEMINI_VERSION" ]]; then
+        echo -e "${RED}⚠️  Warning: Gemini CLI not found or not working${NC}"
+        echo "[$(date)] WARNING: Gemini CLI not functional" >> "$LOGFILE"
+    else
+        echo -e "${GREEN}✓ Gemini CLI: $GEMINI_VERSION${NC}"
+    fi
+}
+
 # Main monitoring routine
 echo -e "${GREEN}🔍 Starting security monitor...${NC}"
 echo "Security Preset: $SECURITY_PRESET"
@@ -114,6 +127,8 @@ echo ""
 check_network
 echo ""
 check_claude_integrity
+echo ""
+check_gemini_integrity
 
 echo ""
 echo -e "${GREEN}✅ Security check complete${NC}"

--- a/.devcontainer/scripts/tests/test-container.sh
+++ b/.devcontainer/scripts/tests/test-container.sh
@@ -22,6 +22,7 @@ docker run --rm \
     echo 'npm: ' && npm --version
     echo -n 'Claude Code: ' && claude --version 2>/dev/null || echo 'installed'
     echo -n 'Claude Flow: ' && claude-flow --version 2>/dev/null || echo 'alpha installed'
+    echo -n 'Gemini CLI: ' && gemini --version 2>/dev/null || echo 'installed'
     echo -n 'Git: ' && git --version
     echo -n 'Zsh: ' && zsh --version
   "

--- a/.devcontainer/scripts/tests/test-devcontainer.sh
+++ b/.devcontainer/scripts/tests/test-devcontainer.sh
@@ -74,7 +74,7 @@ if [ $? -eq 0 ]; then
     echo ""
     echo "6️⃣ Testing tool installations..."
     # Note: claude-flow is installed during postCreate, not during build
-    for tool in node npm claude git; do
+    for tool in node npm claude gemini git; do
         if docker exec "$CONTAINER_ID" which $tool > /dev/null 2>&1; then
             echo -e "   ${GREEN}✓${NC} $tool installed"
         else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to SwarmContainer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-07-16
+
+### Added
+- Gemini CLI installed globally for easy access to Google's multimodal models
+
 ## [1.0.0] - 2025-01-15
 
 ### Added
@@ -35,4 +40,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Persistent command history across container restarts
 - Modern CLI tools: ripgrep, fzf, bat, delta
 
+[1.0.1]: https://github.com/dean0x/swarm-container/releases/tag/v1.0.1
 [1.0.0]: https://github.com/dean0x/swarm-container/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A secure, isolated development container for running agentic swarms, and CLIs wi
 - **💻 Local Development Ready** - Full source code for both claude-flow and ruv-FANN in your workspace - modify, test, and contribute back
 - **⚡ Zero-Latency MCP** - Local MCP servers eliminate network roundtrips for lightning-fast agent coordination
 - **🔧 Production + Development** - Global npm installs for reliability, plus source code for hacking and exploration
+- **🌟 Gemini Ready** - Google Gemini CLI pre-installed for multimodal experimentation
 - **📦 Smart Fallbacks** - Multiple installation strategies ensure everything works on your machine (ARM, x86, Mac, Linux)
 - **🧪 Battle-Tested** - Comprehensive test suite validates your setup before you even start coding
 
@@ -29,7 +30,7 @@ A secure, isolated development container for running agentic swarms, and CLIs wi
 
 | [Claude Code](https://claude.ai/code) | [OpenCode](https://github.com/opencode) | [Codex](https://openai.com/codex) | [Gemini](https://gemini.google.com) |
 |:---:|:---:|:---:|:---:|
-| ✅ **Available** | 🔜 Coming Soon | 🔜 Coming Soon | 🔜 Coming Soon |
+| ✅ **Available** | 🔜 Coming Soon | 🔜 Coming Soon | ✅ **Available** |
 
 ## Prerequisites
 
@@ -139,6 +140,9 @@ claude --dangerously-skip-permissions
 
 # Step 2: Verify installation
 claude-flow --version
+
+# Optional: verify Gemini CLI
+gemini --version
 
 # Step 3: Start building!
 # Quick swarm spawn

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -9,6 +9,7 @@ This document tracks the current working versions of the core components in the 
 | **Claude Code** | v1.0.51 | npm: `@anthropic-ai/claude-code` | Installed globally via npm |
 | **Claude Flow** | v2.0.0-alpha.53 | npm: `claude-flow@alpha` | Installed globally from npm, source in `/workspace/deps/claude-flow` |
 | **ruv-FANN/ruv-swarm** | v1.0.18 | GitHub: `ruvnet/ruv-FANN` | Cloned to `/workspace/deps/ruv-FANN`, ruv-swarm installed with `--production` |
+| **Gemini CLI** | v0.1.12 | npm: `@google/gemini-cli` | Installed globally via npm |
 
 ## Container Base
 


### PR DESCRIPTION
## Summary
- install `@google/gemini-cli` globally
- mention Gemini CLI in README and quick-start docs
- record Gemini CLI version
- add Gemini CLI history commands
- update security monitor and tests for Gemini
- document Gemini CLI in changelog

## Testing
- `bash .devcontainer/scripts/tests/test-devcontainer.sh` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6877ebd46ac083238c4b6e93d4b60979