### PR TITLE
feat: Simplify default MCP server configuration

### DIFF
--- a/config/.mcp.config
+++ b/config/.mcp.config
@@ -1,26 +1,10 @@
 {
   "mcpServers": {
-    "browser-tools": {
-      "command": "npx",
-      "args": [
-        "@agentdeskai/browser-tools-mcp@latest"
-      ]
-    },
     "playwright": {
       "command": "npx",
       "args": [
         "@playwright/mcp@latest"
       ]
-    },
-    "tavily": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "tavily-mcp@latest"
-      ],
-      "env": {
-        "TAVILY_API_KEY": "${TAVILY_API_KEY:-}"
-      }
     },
     "browsermcp": {
       "command": "npx",

--- a/config/README.md
+++ b/config/README.md
@@ -36,21 +36,13 @@ To add or modify MCP servers:
 
 ### Default MCP Servers
 
-- **browser-tools**: Browser automation and web scraping
 - **playwright**: Web testing and automation
-- **tavily**: AI-powered search (requires TAVILY_API_KEY)
 - **browsermcp**: Browser interaction capabilities
 - **context7**: Context management and retrieval
 
 ### API Keys
 
-Some MCP servers require API keys. Set these as environment variables:
-
-```bash
-export TAVILY_API_KEY="your-api-key-here"
-```
-
-Or add them to your `.env` file if using docker-compose.
+If you add MCP servers that require API keys, set them as environment variables or add them to your `.env` file if using docker-compose.
 
 ## Automatic Configuration Updates
 

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -63,7 +63,6 @@
     "CUSTOM_ALLOWED_DOMAINS": "${localEnv:CUSTOM_ALLOWED_DOMAINS:}",
     "NODE_ENV": "development",
     "ENABLE_MCP_WATCHER": "${localEnv:ENABLE_MCP_WATCHER:false}",
-    "TAVILY_API_KEY": "${localEnv:TAVILY_API_KEY:}",
     "CLAUDE_CODE_INSTANCES": "${localEnv:CLAUDE_CODE_INSTANCES:6}"
   },
   "overrideCommand": true,


### PR DESCRIPTION
## Summary
Simplifies the default MCP server configuration by removing servers that require API keys, making the out-of-box experience smoother for new users.

## Changes Made

### Removed MCP Servers
- **browser-tools** (`@agentdeskai/browser-tools-mcp`) - Browser automation tools
- **tavily** (`tavily-mcp`) - Required TAVILY_API_KEY, potential barrier for new users

### Kept MCP Servers  
- **playwright** - Web testing and automation
- **browsermcp** - Browser interaction capabilities
- **context7** - Context management and retrieval

### Configuration Updates
- Updated `config/.mcp.config` to remove browser-tools and tavily
- Removed `TAVILY_API_KEY` environment variable from `devcontainer.json`
- Updated `config/README.md` documentation to reflect new server list

## Motivation
- Simplifies initial setup - no API keys required
- Reduces configuration complexity for new users
- Users can still add tavily or other servers later if needed
- Keeps the most versatile browser automation tools (playwright, browsermcp)

## Breaking Changes
None for existing users - the removed servers can be re-added to local configs if needed.

## Test Plan
- [x] JSON configuration is valid
- [x] Documentation updated
- [x] Container builds successfully
- [x] MCP servers initialize properly
- [x] Playwright and browsermcp functionality works